### PR TITLE
Remove qos transient

### DIFF
--- a/cascade_lifecycle_msgs/msg/Activation.msg
+++ b/cascade_lifecycle_msgs/msg/Activation.msg
@@ -1,5 +1,7 @@
 uint8 ADD=0
 uint8 REMOVE=1
+uint8 CONFIRM_ADD=2
+uint8 CONFIRM_REMOVE=3
 
 uint8 operation_type
 

--- a/rclcpp_cascade_lifecycle/include/rclcpp_cascade_lifecycle/rclcpp_cascade_lifecycle.hpp
+++ b/rclcpp_cascade_lifecycle/include/rclcpp_cascade_lifecycle/rclcpp_cascade_lifecycle.hpp
@@ -18,6 +18,7 @@
 #include <set>
 #include <map>
 #include <string>
+#include <list>
 
 #include "rclcpp/node_options.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"

--- a/rclcpp_cascade_lifecycle/include/rclcpp_cascade_lifecycle/rclcpp_cascade_lifecycle.hpp
+++ b/rclcpp_cascade_lifecycle/include/rclcpp_cascade_lifecycle/rclcpp_cascade_lifecycle.hpp
@@ -40,6 +40,7 @@ namespace rclcpp_cascade_lifecycle
 class CascadeLifecycleNode : public rclcpp_lifecycle::LifecycleNode
 {
 public:
+  RCLCPP_SMART_PTR_DEFINITIONS(CascadeLifecycleNode)
   /// Create a new lifecycle node with the specified name.
   /**
    * \param[in] node_name Name of the node.

--- a/rclcpp_cascade_lifecycle/include/rclcpp_cascade_lifecycle/rclcpp_cascade_lifecycle.hpp
+++ b/rclcpp_cascade_lifecycle/include/rclcpp_cascade_lifecycle/rclcpp_cascade_lifecycle.hpp
@@ -101,16 +101,21 @@ private:
   rclcpp::Subscription<cascade_lifecycle_msgs::msg::State>::SharedPtr states_sub_;
 
   rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::TimerBase::SharedPtr timer_responses_;
 
   std::set<std::string> activators_;
   std::set<std::string> activations_;
   std::map<std::string, uint8_t> activators_state_;
+  std::list<cascade_lifecycle_msgs::msg::Activation> op_pending_;
 
   void activations_callback(const cascade_lifecycle_msgs::msg::Activation::SharedPtr msg);
   void states_callback(const cascade_lifecycle_msgs::msg::State::SharedPtr msg);
   void update_state();
 
   void timer_callback();
+  void timer_responses_callback();
+
+  bool allow_duplicate_names_ {true};
 };
 
 }  // namespace rclcpp_cascade_lifecycle

--- a/rclcpp_cascade_lifecycle/src/rclcpp_cascade_lifecycle/rclcpp_cascade_lifecycle.cpp
+++ b/rclcpp_cascade_lifecycle/src/rclcpp_cascade_lifecycle/rclcpp_cascade_lifecycle.cpp
@@ -47,26 +47,43 @@ CascadeLifecycleNode::CascadeLifecycleNode(
   using std::placeholders::_1;
   using namespace std::chrono_literals;
 
-  activations_pub_ = create_publisher<cascade_lifecycle_msgs::msg::Activation>(
-    "cascade_lifecycle_activations",
-    rclcpp::QoS(1000).keep_all().transient_local().reliable());
+  declare_parameter("allow_duplicate_names", allow_duplicate_names_);
+  get_parameter("allow_duplicate_names", allow_duplicate_names_);
+
+  if (!allow_duplicate_names_) {
+    activations_pub_ = create_publisher<cascade_lifecycle_msgs::msg::Activation>(
+      "cascade_lifecycle_activations", 100);
+
+    activations_sub_ = create_subscription<cascade_lifecycle_msgs::msg::Activation>(
+      "cascade_lifecycle_activations", 100,
+      std::bind(&CascadeLifecycleNode::activations_callback, this, _1));
+  } else {
+    activations_pub_ = create_publisher<cascade_lifecycle_msgs::msg::Activation>(
+      "cascade_lifecycle_activations",
+      rclcpp::QoS(1000).keep_all().transient_local().reliable());
+
+    activations_sub_ = create_subscription<cascade_lifecycle_msgs::msg::Activation>(
+      "cascade_lifecycle_activations",
+      rclcpp::QoS(1000).keep_all().transient_local().reliable(),
+      std::bind(&CascadeLifecycleNode::activations_callback, this, _1));
+  }
 
   states_pub_ = create_publisher<cascade_lifecycle_msgs::msg::State>(
-    "cascade_lifecycle_states", rclcpp::QoS(100));
-
-  activations_sub_ = create_subscription<cascade_lifecycle_msgs::msg::Activation>(
-    "cascade_lifecycle_activations",
-    rclcpp::QoS(1000).keep_all().transient_local().reliable(),
-    std::bind(&CascadeLifecycleNode::activations_callback, this, _1));
+    "cascade_lifecycle_states", 100);
 
   states_sub_ = create_subscription<cascade_lifecycle_msgs::msg::State>(
-    "cascade_lifecycle_states",
-    rclcpp::QoS(100),
+    "cascade_lifecycle_states", 100,
     std::bind(&CascadeLifecycleNode::states_callback, this, _1));
 
   timer_ = create_wall_timer(
     500ms,
     std::bind(&CascadeLifecycleNode::timer_callback, this));
+  
+  if (!allow_duplicate_names_) {
+    timer_responses_ = create_wall_timer(
+      1s,
+      std::bind(&CascadeLifecycleNode::timer_responses_callback, this));
+  }
 
   activations_pub_->on_activate();
   states_pub_->on_activate();
@@ -114,6 +131,12 @@ CascadeLifecycleNode::activations_callback(
         if (activators_state_.find(msg->activator) == activators_state_.end()) {
           activators_state_[msg->activator] = lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN;
         }
+        
+        if (!allow_duplicate_names_) {
+          auto response = *msg;
+          response.operation_type = cascade_lifecycle_msgs::msg::Activation::CONFIRM_ADD;
+          activations_pub_->publish(response);
+        }
       }
       break;
     case cascade_lifecycle_msgs::msg::Activation::REMOVE:
@@ -135,6 +158,40 @@ CascadeLifecycleNode::activations_callback(
 
           if (!any_other_activator) {
             trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+          }
+        }
+
+        if (!allow_duplicate_names_) {
+          auto response = *msg;
+          response.operation_type = cascade_lifecycle_msgs::msg::Activation::CONFIRM_REMOVE;
+          activations_pub_->publish(response);
+        }
+      }
+      break;
+    case cascade_lifecycle_msgs::msg::Activation::CONFIRM_ADD:
+      {
+        auto it = op_pending_.begin();
+        while (it != op_pending_.end()) {
+          if (it->operation_type == cascade_lifecycle_msgs::msg::Activation::ADD &&
+            it->activator == msg->activator && it->activation == msg->activation)
+          {
+            it = op_pending_.erase(it);
+          } else {
+            ++it;
+          }
+        }
+      }
+      break;
+    case cascade_lifecycle_msgs::msg::Activation::CONFIRM_REMOVE:
+      {
+        auto it = op_pending_.begin();
+        while (it != op_pending_.end()) {
+          if (it->operation_type == cascade_lifecycle_msgs::msg::Activation::REMOVE &&
+            it->activator == msg->activator && it->activation == msg->activation)
+          {
+            it = op_pending_.erase(it);
+          } else {
+            ++it;
           }
         }
       }
@@ -171,6 +228,9 @@ CascadeLifecycleNode::add_activation(const std::string & node_name)
       activations_pub_->on_activate();
     }
 
+    if (!allow_duplicate_names_) {
+      op_pending_.push_back(msg);
+    }
     activations_pub_->publish(msg);
   } else {
     RCLCPP_WARN(get_logger(), "Trying to set an auto activation");
@@ -193,6 +253,9 @@ CascadeLifecycleNode::remove_activation(const std::string & node_name)
       activations_pub_->on_activate();
     }
 
+    if (!allow_duplicate_names_) {
+      op_pending_.push_back(msg);
+    }
     activations_pub_->publish(msg);
   } else {
     RCLCPP_WARN(get_logger(), "Trying to remove an auto activation");
@@ -248,6 +311,10 @@ CascadeLifecycleNode::on_cleanup_internal(
       states_pub_->on_activate();
     }
 
+    if (!activations_pub_->is_activated()) {
+      activations_pub_->on_activate();
+    }
+
     states_pub_->publish(msg);
   }
 
@@ -270,6 +337,10 @@ CascadeLifecycleNode::on_shutdown_internal(
     if (!states_pub_->is_activated()) {
       RCLCPP_DEBUG(get_logger(), "Not activated in on_shutdown_internal %d", __LINE__);
       states_pub_->on_activate();
+    }
+
+    if (!activations_pub_->is_activated()) {
+      activations_pub_->on_activate();
     }
 
     states_pub_->publish(msg);
@@ -296,6 +367,10 @@ CascadeLifecycleNode::on_activate_internal(
       states_pub_->on_activate();
     }
 
+    if (!activations_pub_->is_activated()) {
+      activations_pub_->on_activate();
+    }
+
     states_pub_->publish(msg);
   }
 
@@ -320,6 +395,10 @@ CascadeLifecycleNode::on_deactivate_internal(
       states_pub_->on_activate();
     }
 
+    if (!activations_pub_->is_activated()) {
+      activations_pub_->on_activate();
+    }
+
     states_pub_->publish(msg);
   }
 
@@ -342,6 +421,10 @@ CascadeLifecycleNode::on_error_internal(
     if (!states_pub_->is_activated()) {
       RCLCPP_DEBUG(get_logger(), "Not activated in on_error_internal %d", __LINE__);
       states_pub_->on_activate();
+    }
+
+    if (!activations_pub_->is_activated()) {
+      activations_pub_->on_activate();
     }
 
     states_pub_->publish(msg);
@@ -433,6 +516,18 @@ CascadeLifecycleNode::timer_callback()
   states_pub_->publish(msg);
 
   update_state();
+}
+
+void
+CascadeLifecycleNode::timer_responses_callback()
+{
+  for (const auto & msg : op_pending_) {
+    if (!activations_pub_->is_activated()) {
+      activations_pub_->on_activate();
+    }
+
+    activations_pub_->publish(msg);
+  }
 }
 
 }  // namespace rclcpp_cascade_lifecycle

--- a/rclcpp_cascade_lifecycle/src/rclcpp_cascade_lifecycle/rclcpp_cascade_lifecycle.cpp
+++ b/rclcpp_cascade_lifecycle/src/rclcpp_cascade_lifecycle/rclcpp_cascade_lifecycle.cpp
@@ -78,7 +78,7 @@ CascadeLifecycleNode::CascadeLifecycleNode(
   timer_ = create_wall_timer(
     500ms,
     std::bind(&CascadeLifecycleNode::timer_callback, this));
-  
+
   if (!allow_duplicate_names_) {
     timer_responses_ = create_wall_timer(
       1s,
@@ -131,7 +131,7 @@ CascadeLifecycleNode::activations_callback(
         if (activators_state_.find(msg->activator) == activators_state_.end()) {
           activators_state_[msg->activator] = lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN;
         }
-        
+
         if (!allow_duplicate_names_) {
           auto response = *msg;
           response.operation_type = cascade_lifecycle_msgs::msg::Activation::CONFIRM_ADD;

--- a/rclcpp_cascade_lifecycle/test/CMakeLists.txt
+++ b/rclcpp_cascade_lifecycle/test/CMakeLists.txt
@@ -4,3 +4,10 @@ ament_add_gtest(
 )
 ament_target_dependencies(rclcpp_cascade_lifecycle_test ${dependencies})
 target_link_libraries(rclcpp_cascade_lifecycle_test ${PROJECT_NAME})
+
+ament_add_gtest(
+  rclcpp_cascade_lifecycle_test_no_duplicates rclcpp_cascade_lifecycle_test_no_duplicates.cpp
+  TIMEOUT 120
+)
+ament_target_dependencies(rclcpp_cascade_lifecycle_test_no_duplicates ${dependencies})
+target_link_libraries(rclcpp_cascade_lifecycle_test_no_duplicates ${PROJECT_NAME})

--- a/rclcpp_cascade_lifecycle/test/rclcpp_cascade_lifecycle_test_no_duplicates.cpp
+++ b/rclcpp_cascade_lifecycle/test/rclcpp_cascade_lifecycle_test_no_duplicates.cpp
@@ -1,0 +1,1973 @@
+// Copyright 2019 Intelligent Robotics Lab
+// Copyright 2021 Homalozoa, Xiaomi Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+#include <regex>
+#include <iostream>
+#include <memory>
+
+
+#include "rclcpp_cascade_lifecycle/rclcpp_cascade_lifecycle.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "gtest/gtest.h"
+
+class TestNode : public rclcpp_cascade_lifecycle::CascadeLifecycleNode
+{
+public:
+  explicit TestNode(
+    const std::string & name,
+    const std::string & ns = "",
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
+  : CascadeLifecycleNode(name, ns, options),
+    my_state_(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
+  {
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_configure(const rclcpp_lifecycle::State &)
+  {
+    my_state_ = lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE;
+
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State &)
+  {
+    my_state_ = lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE;
+
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State &)
+  {
+    my_state_ = lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE;
+
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+  uint8_t get_my_state() {return my_state_;}
+
+private:
+  uint8_t my_state_;
+};
+
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_managing_basic)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_a = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_A", options);
+  auto node_b = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_B", options);
+  auto node_c = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_C", options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_a->get_node_base_interface());
+  executor.add_node(node_b->get_node_base_interface());
+  executor.add_node(node_c->get_node_base_interface());
+
+  node_a->add_activation("node_B");
+  node_a->add_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_EQ(node_a->get_activations().size(), 2u);
+  ASSERT_TRUE(node_b->get_activations().empty());
+  ASSERT_EQ(node_b->get_activators().size(), 1u);
+  ASSERT_TRUE(node_c->get_activations().empty());
+  ASSERT_EQ(node_c->get_activators().size(), 1u);
+}
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_managing_late_joining)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_a = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_A", options);
+  auto node_b = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_B", options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_a->get_node_base_interface());
+  executor.add_node(node_b->get_node_base_interface());
+
+  node_a->add_activation("node_B");
+  node_a->add_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_EQ(node_a->get_activations().size(), 2u);
+  ASSERT_TRUE(node_b->get_activations().empty());
+  ASSERT_EQ(node_b->get_activators().size(), 1u);
+
+  node_b = nullptr;
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 3.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  // auto node_b2 = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_B");
+  auto node_c = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_C", options);
+  executor.add_node(node_c->get_node_base_interface());
+  // executor.add_node(node_b2->get_node_base_interface());
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_EQ(node_a->get_activations().size(), 2u);
+  // ASSERT_TRUE(node_b2->get_activations().empty());
+  // ASSERT_EQ(node_b2->get_activators().size(), 1u);
+  ASSERT_TRUE(node_c->get_activations().empty());
+  ASSERT_EQ(node_c->get_activators().size(), 1u);
+}
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_chained)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_a = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_A", options);
+  auto node_b = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_B", options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_a->get_node_base_interface());
+  executor.add_node(node_b->get_node_base_interface());
+
+  node_a->add_activation("node_B");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_EQ(node_a->get_activations().size(), 1u);
+  ASSERT_TRUE(node_b->get_activations().empty());
+  ASSERT_EQ(node_b->get_activators().size(), 1u);
+
+  ASSERT_TRUE(node_a->get_activators_state().empty());
+  ASSERT_FALSE(node_b->get_activators_state().empty());
+  ASSERT_EQ(node_b->get_activators_state().size(), 1u);
+  ASSERT_EQ(node_b->get_activators_state().begin()->first, "node_A");
+  ASSERT_EQ(
+    node_b->get_activators_state().begin()->second,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators_state().empty());
+  ASSERT_FALSE(node_b->get_activators_state().empty());
+  ASSERT_EQ(node_b->get_activators_state().size(), 1u);
+  ASSERT_EQ(node_b->get_activators_state().begin()->first, "node_A");
+  ASSERT_EQ(
+    node_b->get_activators_state().begin()->second,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators_state().empty());
+  ASSERT_FALSE(node_b->get_activators_state().empty());
+  ASSERT_EQ(node_b->get_activators_state().size(), 1u);
+  ASSERT_EQ(node_b->get_activators_state().begin()->first, "node_A");
+  ASSERT_EQ(
+    node_b->get_activators_state().begin()->second,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators_state().empty());
+  ASSERT_FALSE(node_b->get_activators_state().empty());
+  ASSERT_EQ(node_b->get_activators_state().size(), 1u);
+  ASSERT_EQ(node_b->get_activators_state().begin()->first, "node_A");
+  ASSERT_EQ(
+    node_b->get_activators_state().begin()->second,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+}
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_a = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_A", options);
+  auto node_b = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_B", options);
+  auto node_c = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_C", options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_a->get_node_base_interface());
+  executor.add_node(node_b->get_node_base_interface());
+  executor.add_node(node_c->get_node_base_interface());
+
+  node_a->add_activation("node_C");
+  node_b->add_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_EQ(node_a->get_activations().size(), 1u);
+  ASSERT_TRUE(node_b->get_activators().empty());
+  ASSERT_EQ(node_b->get_activations().size(), 1u);
+  ASSERT_TRUE(node_c->get_activations().empty());
+  ASSERT_EQ(node_c->get_activators().size(), 2u);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    node_b->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_b->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_b->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_b->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  node_b->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_b->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_c->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_a->remove_activation("node_C");
+  node_b->remove_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_c->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+}
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, fast_change)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_a = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_A", options);
+  auto node_b = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_B", options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_a->get_node_base_interface());
+  executor.add_node(node_b->get_node_base_interface());
+
+  node_a->add_activation("node_B");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_EQ(node_a->get_activations().size(), 1u);
+  ASSERT_FALSE(node_b->get_activators().empty());
+  ASSERT_EQ(node_b->get_activations().size(), 0u);
+  ASSERT_FALSE(node_b->get_activators_state().empty());
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+}
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_a = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_A", options);
+  auto node_b = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_B", options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_a->get_node_base_interface());
+  executor.add_node(node_b->get_node_base_interface());
+
+  node_a->add_activation("node_B");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_EQ(node_a->get_activations().size(), 1u);
+  ASSERT_FALSE(node_b->get_activators().empty());
+  ASSERT_EQ(node_b->get_activations().size(), 0u);
+  ASSERT_FALSE(node_b->get_activators_state().empty());
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a = nullptr;
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 3.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_TRUE(node_b->get_activators().empty());
+  ASSERT_TRUE(node_b->get_activators_state().empty());
+  ASSERT_EQ(node_b->get_activations().size(), 0u);
+}
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_a = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_A", options);
+  auto node_b = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_B", options);
+  auto node_c = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>("node_C", options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_a->get_node_base_interface());
+  executor.add_node(node_b->get_node_base_interface());
+  executor.add_node(node_c->get_node_base_interface());
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    node_b->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  ASSERT_EQ(
+    node_b->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(
+    node_b->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  ASSERT_EQ(
+    node_b->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  node_a->add_activation("node_B");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(
+    node_c->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  node_a->remove_activation("node_B");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    node_c->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  node_a->add_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a->remove_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_a->add_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_c->add_activation("node_B");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_c->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a->remove_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_c->remove_activation("node_B");
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_TRUE(node_a->get_activations().empty());
+  ASSERT_TRUE(node_b->get_activators().empty());
+  ASSERT_TRUE(node_b->get_activations().empty());
+  ASSERT_TRUE(node_c->get_activators().empty());
+  ASSERT_TRUE(node_c->get_activations().empty());
+
+
+  node_a->add_activation("node_C");
+  node_b->add_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  node_b->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_c->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_c->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_b->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+}
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, inheritance)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_1 = std::make_shared<TestNode>("node_1", "", options);
+  auto node_2 = std::make_shared<TestNode>("node_2", "", options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_1->get_node_base_interface());
+  executor.add_node(node_2->get_node_base_interface());
+
+  node_1->add_activation("node_2");
+  node_1->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_1->now();
+    while ((node_1->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_1->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_2->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_1->get_my_state(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_2->get_my_state(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_1->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_1->now();
+    while ((node_1->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_1->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_2->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_1->get_my_state(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_2->get_my_state(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_1->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_1->now();
+    while ((node_1->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_1->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_2->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_1->get_my_state(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_2->get_my_state(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+}
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_managing_basic_with_namespace)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_a = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_A",
+    "test_ns",
+    options);
+  auto node_b = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_B",
+    "test_ns",
+    options);
+  auto node_c = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_C",
+    "test_ns",
+    options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_a->get_node_base_interface());
+  executor.add_node(node_b->get_node_base_interface());
+  executor.add_node(node_c->get_node_base_interface());
+
+  node_a->add_activation("node_B");
+  node_a->add_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_EQ(node_a->get_activations().size(), 2u);
+  ASSERT_TRUE(node_b->get_activations().empty());
+  ASSERT_EQ(node_b->get_activators().size(), 1u);
+  ASSERT_TRUE(node_c->get_activations().empty());
+  ASSERT_EQ(node_c->get_activators().size(), 1u);
+}
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_managing_late_joining_with_namespace)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_a = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_A",
+    "test_ns",
+    options);
+  auto node_b = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_B",
+    "test_ns",
+    options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_a->get_node_base_interface());
+  executor.add_node(node_b->get_node_base_interface());
+
+  node_a->add_activation("node_B");
+  node_a->add_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_EQ(node_a->get_activations().size(), 2u);
+  ASSERT_TRUE(node_b->get_activations().empty());
+  ASSERT_EQ(node_b->get_activators().size(), 1u);
+
+  node_b = nullptr;
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 3.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  // auto node_b2 = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+  //   "node_B",
+  //   "test_ns");
+  auto node_c = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_C",
+    "test_ns",
+    options);
+  executor.add_node(node_c->get_node_base_interface());
+  // executor.add_node(node_b2->get_node_base_interface());
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_EQ(node_a->get_activations().size(), 2u);
+  // ASSERT_TRUE(node_b2->get_activations().empty());
+  // ASSERT_EQ(node_b2->get_activators().size(), 1u);
+  ASSERT_TRUE(node_c->get_activations().empty());
+  ASSERT_EQ(node_c->get_activators().size(), 1u);
+}
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_chained_with_namespace)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_a = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_A",
+    "test_ns",
+    options);
+  auto node_b = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_B",
+    "test_ns",
+    options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_a->get_node_base_interface());
+  executor.add_node(node_b->get_node_base_interface());
+
+  node_a->add_activation("node_B");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_EQ(node_a->get_activations().size(), 1u);
+  ASSERT_TRUE(node_b->get_activations().empty());
+  ASSERT_EQ(node_b->get_activators().size(), 1u);
+
+  ASSERT_TRUE(node_a->get_activators_state().empty());
+  ASSERT_FALSE(node_b->get_activators_state().empty());
+  ASSERT_EQ(node_b->get_activators_state().size(), 1u);
+  ASSERT_EQ(node_b->get_activators_state().begin()->first, "node_A");
+  ASSERT_EQ(
+    node_b->get_activators_state().begin()->second,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators_state().empty());
+  ASSERT_FALSE(node_b->get_activators_state().empty());
+  ASSERT_EQ(node_b->get_activators_state().size(), 1u);
+  ASSERT_EQ(node_b->get_activators_state().begin()->first, "node_A");
+  ASSERT_EQ(
+    node_b->get_activators_state().begin()->second,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators_state().empty());
+  ASSERT_FALSE(node_b->get_activators_state().empty());
+  ASSERT_EQ(node_b->get_activators_state().size(), 1u);
+  ASSERT_EQ(node_b->get_activators_state().begin()->first, "node_A");
+  ASSERT_EQ(
+    node_b->get_activators_state().begin()->second,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators_state().empty());
+  ASSERT_FALSE(node_b->get_activators_state().empty());
+  ASSERT_EQ(node_b->get_activators_state().size(), 1u);
+  ASSERT_EQ(node_b->get_activators_state().begin()->first, "node_A");
+  ASSERT_EQ(
+    node_b->get_activators_state().begin()->second,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+}
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained_with_namespace)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_a = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_A",
+    "test_ns",
+    options);
+  auto node_b = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_B",
+    "test_ns",
+    options);
+  auto node_c = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_C",
+    "test_ns",
+    options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_a->get_node_base_interface());
+  executor.add_node(node_b->get_node_base_interface());
+  executor.add_node(node_c->get_node_base_interface());
+
+  node_a->add_activation("node_C");
+  node_b->add_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_EQ(node_a->get_activations().size(), 1u);
+  ASSERT_TRUE(node_b->get_activators().empty());
+  ASSERT_EQ(node_b->get_activations().size(), 1u);
+  ASSERT_TRUE(node_c->get_activations().empty());
+  ASSERT_EQ(node_c->get_activators().size(), 2u);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    node_b->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_b->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_b->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_b->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  node_b->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_b->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_c->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_a->remove_activation("node_C");
+  node_b->remove_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_c->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+}
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, fast_change_with_namespace)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_a = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_A",
+    "test_ns",
+    options);
+  auto node_b = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_B",
+    "test_ns",
+    options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_a->get_node_base_interface());
+  executor.add_node(node_b->get_node_base_interface());
+
+  node_a->add_activation("node_B");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_EQ(node_a->get_activations().size(), 1u);
+  ASSERT_FALSE(node_b->get_activators().empty());
+  ASSERT_EQ(node_b->get_activations().size(), 0u);
+  ASSERT_FALSE(node_b->get_activators_state().empty());
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+}
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_with_namespace)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_a = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_A",
+    "test_ns",
+    options);
+  auto node_b = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_B",
+    "test_ns",
+    options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_a->get_node_base_interface());
+  executor.add_node(node_b->get_node_base_interface());
+
+  node_a->add_activation("node_B");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_EQ(node_a->get_activations().size(), 1u);
+  ASSERT_FALSE(node_b->get_activators().empty());
+  ASSERT_EQ(node_b->get_activations().size(), 0u);
+  ASSERT_FALSE(node_b->get_activators_state().empty());
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a = nullptr;
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 3.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_TRUE(node_b->get_activators().empty());
+  ASSERT_TRUE(node_b->get_activators_state().empty());
+  ASSERT_EQ(node_b->get_activations().size(), 0u);
+}
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with_namespace)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_a = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_A",
+    "test_ns",
+    options);
+  auto node_b = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_B",
+    "test_ns",
+    options);
+  auto node_c = std::make_shared<rclcpp_cascade_lifecycle::CascadeLifecycleNode>(
+    "node_C",
+    "test_ns",
+    options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_a->get_node_base_interface());
+  executor.add_node(node_b->get_node_base_interface());
+  executor.add_node(node_c->get_node_base_interface());
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_a->now();
+    while ((node_a->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    node_b->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  ASSERT_EQ(
+    node_b->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(
+    node_b->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  ASSERT_EQ(
+    node_b->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  node_a->add_activation("node_B");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(
+    node_c->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  node_a->remove_activation("node_B");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(
+    node_c->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  node_a->add_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a->remove_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_a->add_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_c->add_activation("node_B");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_c->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a->remove_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_c->remove_activation("node_B");
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+
+  ASSERT_TRUE(node_a->get_activators().empty());
+  ASSERT_TRUE(node_a->get_activations().empty());
+  ASSERT_TRUE(node_b->get_activators().empty());
+  ASSERT_TRUE(node_b->get_activations().empty());
+  ASSERT_TRUE(node_c->get_activators().empty());
+  ASSERT_TRUE(node_c->get_activations().empty());
+
+
+  node_a->add_activation("node_C");
+  node_b->add_activation("node_C");
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  node_b->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_c->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_a->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_c->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_b->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_b->now();
+    while ((node_b->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_a->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_b->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_c->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+}
+
+TEST(rclcpp_cascade_lifecycle_no_duplicates, inheritance_with_namespace)
+{
+  rclcpp::NodeOptions options;
+  options.use_intra_process_comms(true);
+  options.append_parameter_override("allow_duplicate_names", false);
+
+  auto node_1 = std::make_shared<TestNode>(
+    "node_1",
+    "test_ns",
+    options);
+  auto node_2 = std::make_shared<TestNode>(
+    "node_2",
+    "test_ns",
+    options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_1->get_node_base_interface());
+  executor.add_node(node_2->get_node_base_interface());
+
+  node_1->add_activation("node_2");
+  node_1->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_1->now();
+    while ((node_1->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_1->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_2->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_1->get_my_state(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_2->get_my_state(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_1->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_1->now();
+    while ((node_1->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_1->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_2->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_1->get_my_state(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_EQ(node_2->get_my_state(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  node_1->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = node_1->now();
+    while ((node_1->now() - start).seconds() < 2.0) {
+      executor.spin_some();
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(node_1->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_2->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_1->get_my_state(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_EQ(node_2->get_my_state(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/rclcpp_cascade_lifecycle/test/rclcpp_cascade_lifecycle_test_no_duplicates.cpp
+++ b/rclcpp_cascade_lifecycle/test/rclcpp_cascade_lifecycle_test_no_duplicates.cpp
@@ -90,7 +90,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_managing_basic)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -123,7 +123,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_managing_late_joining)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -153,7 +153,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_managing_late_joining)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -185,7 +185,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_chained)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -209,7 +209,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_chained)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -231,7 +231,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_chained)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -253,7 +253,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_chained)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -292,7 +292,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -310,7 +310,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -327,7 +327,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -342,7 +342,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -357,7 +357,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -373,7 +373,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -388,7 +388,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -403,7 +403,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -417,7 +417,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -433,7 +433,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -447,7 +447,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -476,7 +476,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, fast_change)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -494,7 +494,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, fast_change)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -522,7 +522,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -540,7 +540,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -586,7 +586,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -603,7 +603,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -625,7 +625,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -642,7 +642,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -659,7 +659,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -674,7 +674,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -689,7 +689,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -704,7 +704,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -719,7 +719,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -734,7 +734,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -749,7 +749,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -764,7 +764,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -780,7 +780,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -805,7 +805,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -821,7 +821,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -836,7 +836,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -852,7 +852,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -867,7 +867,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -882,7 +882,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -897,7 +897,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -912,7 +912,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter)
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -942,7 +942,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, inheritance)
   {
     rclcpp::Rate rate(10);
     auto start = node_1->now();
-    while ((node_1->now() - start).seconds() < 2.0) {
+    while ((node_1->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -958,7 +958,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, inheritance)
   {
     rclcpp::Rate rate(10);
     auto start = node_1->now();
-    while ((node_1->now() - start).seconds() < 2.0) {
+    while ((node_1->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -974,7 +974,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, inheritance)
   {
     rclcpp::Rate rate(10);
     auto start = node_1->now();
-    while ((node_1->now() - start).seconds() < 2.0) {
+    while ((node_1->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1016,7 +1016,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_managing_basic_with_nam
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1055,7 +1055,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_managing_late_joining_w
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1090,7 +1090,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_managing_late_joining_w
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1128,7 +1128,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_chained_with_namespace)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1152,7 +1152,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_chained_with_namespace)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1174,7 +1174,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_chained_with_namespace)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1196,7 +1196,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activations_chained_with_namespace)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1244,7 +1244,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained_with_n
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1262,7 +1262,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained_with_n
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1279,7 +1279,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained_with_n
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1294,7 +1294,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained_with_n
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1309,7 +1309,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained_with_n
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1325,7 +1325,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained_with_n
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1340,7 +1340,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained_with_n
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1355,7 +1355,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained_with_n
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1369,7 +1369,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained_with_n
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1385,7 +1385,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained_with_n
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1399,7 +1399,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, multiple_activations_chained_with_n
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1434,7 +1434,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, fast_change_with_namespace)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1452,7 +1452,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, fast_change_with_namespace)
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1486,7 +1486,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_with_names
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1504,7 +1504,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_with_names
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1559,7 +1559,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_a->now();
-    while ((node_a->now() - start).seconds() < 2.0) {
+    while ((node_a->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1576,7 +1576,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1598,7 +1598,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1615,7 +1615,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1632,7 +1632,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1647,7 +1647,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1662,7 +1662,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1677,7 +1677,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1692,7 +1692,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1707,7 +1707,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1722,7 +1722,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1737,7 +1737,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1753,7 +1753,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1778,7 +1778,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1794,7 +1794,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1809,7 +1809,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1825,7 +1825,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1840,7 +1840,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1855,7 +1855,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1870,7 +1870,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1885,7 +1885,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, activators_disappearance_inter_with
   {
     rclcpp::Rate rate(10);
     auto start = node_b->now();
-    while ((node_b->now() - start).seconds() < 2.0) {
+    while ((node_b->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1921,7 +1921,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, inheritance_with_namespace)
   {
     rclcpp::Rate rate(10);
     auto start = node_1->now();
-    while ((node_1->now() - start).seconds() < 2.0) {
+    while ((node_1->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1937,7 +1937,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, inheritance_with_namespace)
   {
     rclcpp::Rate rate(10);
     auto start = node_1->now();
-    while ((node_1->now() - start).seconds() < 2.0) {
+    while ((node_1->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }
@@ -1953,7 +1953,7 @@ TEST(rclcpp_cascade_lifecycle_no_duplicates, inheritance_with_namespace)
   {
     rclcpp::Rate rate(10);
     auto start = node_1->now();
-    while ((node_1->now() - start).seconds() < 2.0) {
+    while ((node_1->now() - start).seconds() < 1.0) {
       executor.spin_some();
       rate.sleep();
     }


### PR DESCRIPTION
Hi all

Some QoS are not allowed for nodes for which NodeOptions set `use_intra_process_comms` to true. This PR contains an alternative to modifying the QoS and the protocol. To use this alternative protocol, set `allow_duplicate_names`to `false` because it is not allowed to use nodes with the same name.

I hope it helps