### PR TITLE
Fixed rclpy_cascade_lifecycle package.xml

### DIFF
--- a/cascade_lifecycle_msgs/CMakeLists.txt
+++ b/cascade_lifecycle_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 
 project(cascade_lifecycle_msgs)
 
@@ -17,8 +17,8 @@ find_package(lifecycle_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
-  "msg/Activation.msg" 
-  "msg/State.msg" 
+  "msg/Activation.msg"
+  "msg/State.msg"
  DEPENDENCIES builtin_interfaces lifecycle_msgs
  ADD_LINTER_TESTS
 )

--- a/rclcpp_cascade_lifecycle/CMakeLists.txt
+++ b/rclcpp_cascade_lifecycle/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rclcpp_cascade_lifecycle)
 
 # Default to C99

--- a/rclpy_cascade_lifecycle/package.xml
+++ b/rclpy_cascade_lifecycle/package.xml
@@ -7,8 +7,7 @@
   <maintainer email="jc.manzanares.serrano@gmail.com"> Juan Carlos Manzanares Serrano</maintainer>
   <license>Apache License, Version 2.0</license>
 
-  <depend>rclcpp</depend>
-  <depend>rclcpp_lifecycle</depend>
+  <depend>rclpy</depend>
   <depend>lifecycle_msgs</depend>
   <depend>cascade_lifecycle_msgs</depend>
 


### PR DESCRIPTION
Dependencies are wrong in `rclpy_cascade_lifecycle`

Related to https://build.ros2.org/view/Rdev/job/Rdev__cascade_lifecycle__ubuntu_noble_amd64/8/console